### PR TITLE
Add windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,16 @@ jobs:
         run: |
           which rebar3
           rebar3 version
+  windows-test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2.0.0
+      - name: Install Erlang/OTP
+        uses: ./
+        with:
+          otp-version: 22.2
+        id: install_erlang
+      - name: Run erl
+        run: |
+          $env:PATH = "${{ steps.install_erlang.outputs.erlpath }}\bin;$env:PATH"
+          & erl.exe -eval 'erlang:display({otp_release, erlang:system_info(otp_release)}), halt().' -noshell

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ const path = require("path");
 let main;
 if (process.platform === "win32") {
     let scriptfile = path.join(__dirname, "main.ps1")
-    main = "C:\\Program Files\\PowerShell\\7\\pwsh.EXE -command \". '${scriptfile}'\"";
+    main = `"C:\\Program Files\\PowerShell\\7\\pwsh.EXE" -command ". '${scriptfile}'"`;
 }
 else {
     main = path.join(__dirname, "main.sh")

--- a/main.js
+++ b/main.js
@@ -2,14 +2,14 @@ const { exec } = require("@actions/exec");
 const core = require("@actions/core");
 const path = require("path");
 
-let scriptfile;
+let main;
 if (process.platform === "win32") {
-    scriptfile = "main.ps1";
+    let scriptfile = path.join(__dirname, "main.ps1")
+    main = "C:\\Program Files\\PowerShell\\7\\pwsh.EXE -command \". '${scriptfile}'\"";
 }
 else {
-    scriptfile = "main.sh";
+    main = path.join(__dirname, "main.sh")
 }
 
 const version = core.getInput("otp-version", { required: true });
-const main = path.join(__dirname, scriptfile);
 exec(main, [version]).catch(err => core.setFailed(err.message));

--- a/main.js
+++ b/main.js
@@ -2,6 +2,14 @@ const { exec } = require("@actions/exec");
 const core = require("@actions/core");
 const path = require("path");
 
+let scriptfile;
+if (process.platform === "win32") {
+    scriptfile = "main.ps1";
+}
+else {
+    scriptfile = "main.sh";
+}
+
 const version = core.getInput("otp-version", { required: true });
-const main = path.join(__dirname, "main.sh");
+const main = path.join(__dirname, scriptfile);
 exec(main, [version]).catch(err => core.setFailed(err.message));

--- a/main.ps1
+++ b/main.ps1
@@ -15,6 +15,7 @@ if (!(Test-Path variable:global:PSScriptRoot)) {
 
 # Temporary folder
 $dir = "$PSScriptRoot\$(([System.Guid]::NewGuid()).Guid)"
+mkdir $dir | Out-Null
 Push-Location $dir
 
 # Download erlang

--- a/main.ps1
+++ b/main.ps1
@@ -1,0 +1,43 @@
+#! /usr/bin/pwsh
+param (
+    [Parameter(Mandatory=$true, Position=0)]
+    [int]$version
+)
+
+# Terminate on error
+$ErrorActionPreference = "Stop"
+
+# Ensure we have PSScriptRoot
+if (!(Test-Path variable:global:PSScriptRoot)) {
+    # Support powershell 2.0
+    $PSScriptRoot = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
+}
+
+# Temporary folder
+$dir = "$PSScriptRoot\$(([System.Guid]::NewGuid()).Guid)"
+Push-Location $dir
+
+# Download erlang
+"Downloading Erlang/OTP $version package"
+Invoke-WebRequest -Uri "https://packages.erlang-solutions.com/erlang/erlang/esl-erlang/FLAVOUR_1_general/esl-erlang_$version.0~windows_amd64.exe" -OutFile "esl-erlang_$version.0~windows_amd64.exe"
+
+# Install erlang (runs in background)
+"Installing Erlang/OTP $version"
+& ".\esl-erlang_$version.0~windows_amd64.exe" '/S'
+
+# Wait for it..
+while (@(Get-Process | Where-Object { $_.name -match 'esl-erlang' }).length -gt 0) {
+    Start-Sleep -Milliseconds 100
+}
+
+Pop-Location
+
+# Cleanup (but don't fail on error)
+Remove-Item $dir -Recurse -Force -ErrorAction SilentlyContinue
+
+# Locate installation path
+$erlroot = (Get-ChildItem -path $env:ProgramFiles -filter erl* -directory).FullName
+"Erlang/OTP $version installed in $erlroot"
+
+# Set output of step to erlang path
+"::set-output name=erlpath::$erlroot"

--- a/main.sh
+++ b/main.sh
@@ -5,6 +5,7 @@ set -eo pipefail
 VERSION=$1
 RELEASE=$(lsb_release -cs)
 DIR=$(mktemp -d)
+pushd $DIR
 FILE=esl-erlang_$VERSION-1~ubuntu~$RELEASE\_amd64.deb
 
 echo Installing required packages
@@ -17,7 +18,7 @@ echo Installing Erlang/OTP $VERSION
 sudo dpkg -i $FILE
 
 echo Cleaning up
-cd
+popd
 rm -r $DIR
 
 echo Done!


### PR DESCRIPTION
This pull request will add support for using this action on windows-latest.

I noticed also that main.sh was creating a temporary directory, but not changing into it - so not using it at all, I believe.

I have added a test for windows-latest to verify the change.

**Note**, however, that rebar3 is not included in the erlang solutions distributions for windows (only have "standard" distributions), so it was not included in the test.
