### PR TITLE
Update lbwxgtk3

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -9,7 +9,7 @@ pushd $DIR
 FILE=esl-erlang_$VERSION-1~ubuntu~$RELEASE\_amd64.deb
 
 echo Installing required packages
-sudo apt-get install -y libwxbase3.0-0v5 libwxgtk3.0-0v5 libsctp1
+sudo apt-get install -y libwxbase3.0-0v5 libwxgtk3.0-gtk3-0v5 libsctp1
 
 echo Downloading Erlang/OTP $VERSION package
 wget https://packages.erlang-solutions.com/erlang/debian/pool/$FILE


### PR DESCRIPTION
This is failing using ubuntu-latest when setting up a new project with an error saying that package can't be found. Looking around, this package was renamed.

```
Run gleam-lang/setup-erlang@v1.1.1
/home/runner/work/_actions/gleam-lang/setup-erlang/v1.1.1/main.sh 23.2.1
/tmp/tmp.F7wVCpHFqw ~/work/telemetry_poller/telemetry_poller
Installing required packages
Reading package lists...
Building dependency tree...
Reading state information...
Package libwxgtk3.0-0v5 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libwxgtk3.0-0v5' has no installation candidate
Error: The process '/home/runner/work/_actions/gleam-lang/setup-erlang/v1.1.1/main.sh' failed with exit code 100
```

https://askubuntu.com/questions/1241217/package-libwxgtk3-0-dev-has-no-installation-candidate-on-ubuntu-20-04